### PR TITLE
Fix bit rot

### DIFF
--- a/skip-list.dylan
+++ b/skip-list.dylan
@@ -204,7 +204,7 @@ define primary class <basic-skip-list>
   // The probability to create a new level is 1/fan-out, 
   // controls the fan-out of the equivalent tree.
   // Pugh suggests the value of 1/4 for a good space/time trade-off
-  slot probability :: <number>,
+  constant slot probability :: <number>,
      init-value: 0.25,
      init-keyword: probability:;
   
@@ -278,7 +278,7 @@ end method initialize;
 
 
 define method level-for-size (sl :: <basic-skip-list>, size :: <integer>)
-  ceiling(logn(size, 1 / sl.probability));
+  ceiling(logn(as(<double-float>, size), 1 / sl.probability));
 end method;
 
 
@@ -587,8 +587,9 @@ define sealed primary class <skip-list-node> (<object>)
   // We can seal it safely, because the library user should 
   // not know this class exists.  The search key must be comparable by the 
   // key-order function specified for the skip-list
-  slot key :: <object>, init-value: #f,
-                        init-keyword: key:;
+  constant slot key :: <object>,
+    init-value: #f,
+    init-keyword: key:;
   slot value :: <object>, init-value: #f,
                           init-keyword: value:;
 

--- a/test/tests.dylan
+++ b/test/tests.dylan
@@ -17,25 +17,6 @@ define function make-skip-list ()
 end function;
 
 
-define suite skip-list-suite ()
-  test string-key-test;
-  test make-test;
-  test not-key-order-test;
-  test remove-first-key-test;
-  test remove-last-key-test;
-  test remove-middle-key-test;
-  test empty-test;
-  test backward-iteration-test;
-  test keywise-iteration-test;
-  test missing-test;
-  test reorder-elements-test;
-  test reorder-extra-element-test;
-  test reorder-missing-element-test;
-  test reorder-duped-element-test;
-  test reorder-changed-element-test;
-end suite;
-
-
 define test string-key-test ()
   let skip = make(<skip-list>);
   skip["zzz"] := 1;
@@ -196,5 +177,4 @@ define test reorder-changed-element-test ()
   check-condition("cond check", <error>, skip.element-sequence := sorted);
 end test;
 
-
-run-test-application(skip-list-suite);
+run-test-application();


### PR DESCRIPTION
* Remove warnings by marking some slots constant
* Convert argument to logn to `<double-float>` (not sure how this worked before)
* Remove 'define suite' form from tests.